### PR TITLE
Fix crash with other mods

### DIFF
--- a/pf-src/eu/ha3/mc/presencefootsteps/mcpackage/implem/AcousticsManager.java
+++ b/pf-src/eu/ha3/mc/presencefootsteps/mcpackage/implem/AcousticsManager.java
@@ -53,7 +53,15 @@ public class AcousticsManager extends AcousticsLibrary implements SoundPlayer, D
 		//playStepSound
 		//entity.func_145780_a(xx, yy, zz, blockID);
 		
+		if (blockId == null) {
+			return;
+		}
+		
 		Block.SoundType soundType = blockID.stepSound;
+		
+		if (soundType == null) {
+			return;
+		}
 		
 		if (Minecraft.getMinecraft().theWorld.getBlock(xx, yy + 1, zz) == Blocks.snow_layer)
 		{


### PR DESCRIPTION
For some reason, this method was being called with a null Block, this PR will prevent crashes and will prevent null SoundTypes.

Fixes a NullPointerException crash, which was reported in #15, #11, #12, #16.
